### PR TITLE
fix: use DecimalField for valor and remove number-input spinners

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -5,6 +5,8 @@ from wtforms import (
 )
 from wtforms.validators import DataRequired, Length
 from wtforms.validators import InputRequired, NumberRange, Length
+from wtforms import DecimalField
+from wtforms.widgets import NumberInput
 
 class RegistrationForm(FlaskForm):
     username = StringField('Usuário',
@@ -24,7 +26,8 @@ class ExpenseForm(FlaskForm):
     origem     = StringField('Origem', validators=[DataRequired()])
     vencimento = DateField('Vencimento',
         format='%Y-%m-%d', validators=[DataRequired()])
-    valor      = FloatField('Valor', validators=[DataRequired()])
+    valor      = DecimalField('Valor', places=2, validators=[InputRequired(message="Informe um valor válido"), 
+        NumberRange(min=1, message="Não pode ser negativo")])
     status     = SelectField('Status',
         choices=[('Pago','Pago'),('A pagar','A pagar')])
     quem_paga  = StringField('Quem paga')

--- a/app/templates/expenses/add.html
+++ b/app/templates/expenses/add.html
@@ -14,6 +14,11 @@
     border-color: #808080;
     box-shadow: 0 0 0 0.2rem rgba(27, 27, 27, 0.25);
   }
+  input[type=number]::-webkit-inner-spin-button,
+  input[type=number]::-webkit-outer-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
 </style>
 {% endblock %}
 


### PR DESCRIPTION
## Summary by Sourcery

Update the expense form's 'valor' field for better precision and validation, and hide number input spinners.

Bug Fixes:
- Replace `FloatField` with `DecimalField` for the 'valor' field to handle monetary values accurately.
- Improve validation for the 'valor' field, requiring input and enforcing a minimum value greater than zero.

Enhancements:
- Hide default browser spinners on number input fields.